### PR TITLE
adding a lambda handler

### DIFF
--- a/fastapi/api.py
+++ b/fastapi/api.py
@@ -2,6 +2,7 @@ from datetime import date
 from typing import Iterable
 
 from fastapi import FastAPI
+from mangum import Mangum
 
 from models.hobby import Hobby
 from models.participant import Participant
@@ -25,3 +26,6 @@ def list_all_participants() -> Iterable[Participant]:
 def create_participant(details: Participant) -> Participant:
     participants.append(details)
     return details
+
+
+handler = Mangum(app)

--- a/fastapi/requirements.txt
+++ b/fastapi/requirements.txt
@@ -1,3 +1,4 @@
 pydantic==2.5.3
 fastapi==0.108.0
 uvicorn==0.25.0
+mangum==0.17.0


### PR DESCRIPTION
Adding a lambda handler that can be attached to API Gateway.

Instead of having to read an `event` json and return a `response` json, the [Mangum](https://mangum.io/) library will correctly process the request using the existing request handler.
